### PR TITLE
Create CODE_OF_CONDUCT.md to promote respectful collaboration

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Contributor Covenant Code of Conduct”
+
+## Our Pledge
+We pledge to make participation in this community a welcoming and harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity, level of experience, nationality, personal appearance, race, religion, or sexual orientation.
+
+We aim to create an open and inclusive environment where everyone feels respected and valued.
+
+## Our Standards
+Examples of positive behavior include:
+- Showing empathy and kindness to others  
+- Respecting differing opinions and experiences  
+- Giving and accepting constructive feedback  
+- Taking responsibility and apologizing for mistakes  
+- Focusing on what benefits the community as a whole  
+
+Unacceptable behavior includes:
+- Use of sexualized language or imagery  
+- Trolling, insulting, or harassing comments  
+- Public or private harassment  
+- Publishing private information without consent  
+- Any conduct considered inappropriate in a professional setting  
+
+## Enforcement
+Project maintainers are responsible for enforcing this Code of Conduct.  
+Instances of abusive or unacceptable behavior can be reported by contacting the repository maintainers through GitHub issues or discussions.  
+All complaints will be reviewed and addressed fairly and promptly.
+
+## Scope
+This Code of Conduct applies to all community spaces and when an individual represents the project publicly.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.  
+For more information, visit [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).


### PR DESCRIPTION
This pull request adds a Contributor Covenant Code of Conduct file (CODE_OF_CONDUCT.md) to the repository.
It establishes clear guidelines for respectful participation and helps maintain a positive and inclusive community environment.

> **Changes` Made**

Added a new file: CODE_OF_CONDUCT.md

Defined community standards, reporting process, and enforcement guidelines

Based on the official [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html)

**> Purpose**

To ensure contributors follow ethical collaboration standards and to make this repository more welcoming for everyone, aligning with HacktoberFest 2025 guidelines.